### PR TITLE
feat: add external links to footer icons

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -7,8 +7,20 @@ function Footer() {
   return (
     <div className="footer">
       <div className="socialMedia">
-        <GitHubIcon />
-        <LinkedInIcon />
+        <a
+          href="https://github.com/IsaacRodgz"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <GitHubIcon />
+        </a>
+        <a
+          href="https://www.linkedin.com/in/isaacrodgz/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <LinkedInIcon />
+        </a>
       </div>
       <p> &copy; 2022 Isaac Rodríguez. All Rights Reserved.</p>
     </div>


### PR DESCRIPTION
## Summary
- link footer GitHub and LinkedIn icons to external profiles, opening in new tabs

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6897b4eece908329aaf299bcab64219e