### PR TITLE
Open external links in new tab on Home page

### DIFF
--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -17,10 +17,20 @@ function Home() {
             conversational agents through the implementation of NLP
             technologies.
           </p>
-          <Link href="https://github.com/IsaacRodgz">
+          <Link
+            href="https://github.com/IsaacRodgz"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="GitHub"
+          >
             <GitHubIcon />
           </Link>
-          <Link href="https://www.linkedin.com/in/isaacrodgz/">
+          <Link
+            href="https://www.linkedin.com/in/isaacrodgz/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="LinkedIn"
+          >
             <LinkedInIcon />
           </Link>
         </div>


### PR DESCRIPTION
## Summary
- Ensure Home page social links open in a new tab
- Add `target="_blank"`, `rel="noopener noreferrer"`, and `aria-label` attributes to GitHub and LinkedIn icons

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897db8181c883299019692ad9e6b354