### PR TITLE
Use project IDs for navigation and fix typo

### DIFF
--- a/src/helpers/ProjectList.js
+++ b/src/helpers/ProjectList.js
@@ -3,6 +3,7 @@ import Proj2 from '../assets/web-extension.png';
 
 export const ProjectList = [
   {
+    id: 1,
     name: 'Multimodal Transformer with GMU Fusion',
     description: `This project was the result of my master thesis. I proposed a novel architecture based on the Transformer architecture.
     This model is capable of fusing information from multiple modalities, including: text, images, video, audio and tabular data. With this model
@@ -13,10 +14,11 @@ export const ProjectList = [
     url: 'https://github.com/IsaacRodgz/multimodal-transformers-movies',
   },
   {
+    id: 2,
     name: 'Fake News Validator',
     description: `In this project I developed a Google Chrome extension both for the frontend and the backend side. This plugin was the result
     of a project in Omdena Mexico challenge organization where the objective was to create a product that could guide users to decide if a
-    news article is fake or not. The extension consists of the user interface (the chrome extension itself), a backend API written with FastAPI and deveral
+    news article is fake or not. The extension consists of the user interface (the chrome extension itself), a backend API written with FastAPI and several
     Document DBs used by the backend API.`,
     image: Proj2,
     skills: 'Python, FastAPI, Javascript, HTML, CSS',

--- a/src/pages/ProjectDisplay.js
+++ b/src/pages/ProjectDisplay.js
@@ -7,7 +7,7 @@ import '../styles/ProjectDisplay.css';
 
 function ProjectDisplay() {
   const { id } = useParams();
-  const project = ProjectList[id];
+  const project = ProjectList.find((p) => p.id.toString() === id);
   return (
     <div className="project">
       <h1> {project.name}</h1>

--- a/src/pages/Projects.js
+++ b/src/pages/Projects.js
@@ -9,11 +9,11 @@ function Projects() {
     <div className="projects">
       <h1> My Personal Projects </h1>
       <div className="projectList">
-        {ProjectList.map((project, idx) => {
+        {ProjectList.map((project) => {
           return (
             <ProjectItem
-              key={idx}
-              id={idx}
+              key={project.id}
+              id={project.id}
               name={project.name}
               image={project.image}
             />


### PR DESCRIPTION
## Summary
- add unique `id` fields to each project and fix a spelling error
- key project items by id and navigate using `project.id`
- look up projects by id when displaying details

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897ddadd0688329a89b574d385d51b7