### PR TITLE
Handle missing project display gracefully

### DIFF
--- a/src/__tests__/ProjectDisplay.test.js
+++ b/src/__tests__/ProjectDisplay.test.js
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import ProjectDisplay from '../pages/ProjectDisplay';
+
+test('renders fallback message when project is not found', () => {
+  render(
+    <MemoryRouter initialEntries={['/project/999']}>
+      <Routes>
+        <Route path="/project/:id" element={<ProjectDisplay />} />
+      </Routes>
+    </MemoryRouter>
+  );
+  expect(screen.getByText(/Project not found/i)).toBeInTheDocument();
+});

--- a/src/pages/ProjectDisplay.js
+++ b/src/pages/ProjectDisplay.js
@@ -8,6 +8,15 @@ import '../styles/ProjectDisplay.css';
 function ProjectDisplay() {
   const { id } = useParams();
   const project = ProjectList[id];
+
+  if (!project) {
+    return (
+      <div className="project">
+        <h1>Project not found</h1>
+      </div>
+    );
+  }
+
   return (
     <div className="project">
       <h1> {project.name}</h1>


### PR DESCRIPTION
## Summary
- guard against invalid project IDs in ProjectDisplay
- add unit test for missing project case

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6897dda3f0c083299751a65e0bcc0568