### PR TITLE
Lazy load routes with React.lazy and Suspense

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,23 +1,27 @@
 import './App.css';
-import Home from './pages/Home';
-import Experience from './pages/Experience';
-import Projects from './pages/Projects';
+import { Suspense, lazy } from 'react';
 import Navbar from './components/Navbar';
 import Footer from './components/Footer';
-import ProjectDisplay from './pages/ProjectDisplay';
 import { Routes, Route, HashRouter } from 'react-router-dom';
+
+const Home = lazy(() => import('./pages/Home'));
+const Experience = lazy(() => import('./pages/Experience'));
+const Projects = lazy(() => import('./pages/Projects'));
+const ProjectDisplay = lazy(() => import('./pages/ProjectDisplay'));
 
 function App() {
   return (
     <div className="App">
       <HashRouter>
         <Navbar />
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/projects" element={<Projects />} />
-          <Route path="/project/:id" element={<ProjectDisplay />} />
-          <Route path="/experience" element={<Experience />} />
-        </Routes>
+        <Suspense fallback={<div>Loading...</div>}>
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/projects" element={<Projects />} />
+            <Route path="/project/:id" element={<ProjectDisplay />} />
+            <Route path="/experience" element={<Experience />} />
+          </Routes>
+        </Suspense>
         <Footer />
       </HashRouter>
     </div>


### PR DESCRIPTION
## Summary
- use `React.lazy` to defer loading of Home, Experience, Projects, and ProjectDisplay pages
- wrap route configuration in `<Suspense>` with a loading placeholder

## Testing
- `CI=true npm test --silent 2>&1 | tail -n 5`


------
https://chatgpt.com/codex/tasks/task_e_6897df826fb08329995fa135216e835d